### PR TITLE
Add retry to certain K8s-related calls to overcome transient failure

### DIFF
--- a/jax/BUILD
+++ b/jax/BUILD
@@ -1143,7 +1143,7 @@ pytype_strict_library(
         ":traceback_util",
         ":util",
         "//jax/_src/lib",
-    ],
+    ] + py_deps("numpy"),
 )
 
 # Public JAX libraries below this point.

--- a/jax/_src/clusters/k8s_cluster.py
+++ b/jax/_src/clusters/k8s_cluster.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from functools import cache
 from itertools import chain
+import logging
 import numpy as np
 import os
 import socket
@@ -25,7 +26,6 @@ import textwrap
 import warnings
 from jax._src import clusters
 
-import logging
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
1. When a pod queries for its own metadata immediately after launch, the query may not returne a match due to latency in the K8s pod database. This typically resolves by itself quickly as the database eventually achieves consistency.
2. When follower pods try to establish connection to the coordinator pod before its DNS record has been published, they will hit an NXDOMAIN error that will be cached for the next 30 seconds. This can be avoided by waiting for a short period before making the first connection attempt.